### PR TITLE
add multi-pass inference code

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,3 +31,5 @@ training:
 hydra:
   run:
     dir: logs
+
+run_additional_inference: True  # Set to false to not run multipass inference.

--- a/main.py
+++ b/main.py
@@ -57,6 +57,12 @@ def validate_or_test(opt, model, partition, epoch=None):
             scalar_outputs = model.forward_downstream_classification_model(
                 inputs, labels
             )
+
+            if opt.run_additional_inference:
+                scalar_outputs = model.forward_downstream_multi_pass(
+                    inputs, labels, scalar_outputs=scalar_outputs
+                )
+                
             test_results = utils.log_results(
                 test_results, scalar_outputs, num_steps_per_epoch
             )

--- a/src/ff_mnist.py
+++ b/src/ff_mnist.py
@@ -12,7 +12,7 @@ class FF_MNIST(torch.utils.data.Dataset):
         self.uniform_label = torch.ones(self.num_classes) / self.num_classes
 
     def __getitem__(self, index):
-        pos_sample, neg_sample, neutral_sample, class_label = self._generate_sample(
+        pos_sample, neg_sample, neutral_sample, all_sample, class_label = self._generate_sample(
             index
         )
 
@@ -20,6 +20,7 @@ class FF_MNIST(torch.utils.data.Dataset):
             "pos_images": pos_sample,
             "neg_images": neg_sample,
             "neutral_sample": neutral_sample,
+            "all_sample": all_sample
         }
         labels = {"class_labels": class_label}
         return inputs, labels
@@ -32,7 +33,7 @@ class FF_MNIST(torch.utils.data.Dataset):
             torch.tensor(class_label), num_classes=self.num_classes
         )
         pos_sample = sample.clone()
-        pos_sample[:, 0, : self.num_classes] = one_hot_label
+        pos_sample[0, 0, : self.num_classes] = one_hot_label
         return pos_sample
 
     def _get_neg_sample(self, sample, class_label):
@@ -44,12 +45,21 @@ class FF_MNIST(torch.utils.data.Dataset):
             torch.tensor(wrong_class_label), num_classes=self.num_classes
         )
         neg_sample = sample.clone()
-        neg_sample[:, 0, : self.num_classes] = one_hot_label
+        neg_sample[0, 0, : self.num_classes] = one_hot_label
         return neg_sample
 
     def _get_neutral_sample(self, z):
-        z[:, 0, : self.num_classes] = self.uniform_label
+        z[0, 0, : self.num_classes] = self.uniform_label
         return z
+    
+    def _get_all_sample(self, sample):
+        all_samples = torch.zeros((self.num_classes, sample.shape[0], sample.shape[1], sample.shape[2]))
+        for i in range(self.num_classes):
+            all_samples[i, :, :, :] = sample.clone()
+            one_hot_label = torch.nn.functional.one_hot(
+            torch.tensor(i), num_classes=self.num_classes)
+            all_samples[i, 0, 0, : self.num_classes] = one_hot_label.clone()
+        return all_samples
 
     def _generate_sample(self, index):
         # Get MNIST sample.
@@ -57,4 +67,5 @@ class FF_MNIST(torch.utils.data.Dataset):
         pos_sample = self._get_pos_sample(sample, class_label)
         neg_sample = self._get_neg_sample(sample, class_label)
         neutral_sample = self._get_neutral_sample(sample)
-        return pos_sample, neg_sample, neutral_sample, class_label
+        all_sample = self._get_all_sample(sample)
+        return pos_sample, neg_sample, neutral_sample, all_sample, class_label


### PR DESCRIPTION
The code changes facilitate multi-pass inference: passing an image with the one hot labels encoded into the image in a different pixel each time and choosing the predicted label as the image that yielded maximum sum of squared activations.

- changed data loading to also load samples of images with each image having the label encoded in a different pixel (from first 10 pixels)
- added function to compute the multi-pass inference label
- added code in `main.py` to run the new inference during `validate_or_test`
- added a config variable to run the code without needing to do this inference